### PR TITLE
Added boolean return value for MzMLWriter::writeSpectra()

### DIFF
--- a/src/MSToolkit/mzMLWriter.cpp
+++ b/src/MSToolkit/mzMLWriter.cpp
@@ -256,8 +256,12 @@ bool MzMLWriter::writeSpectra(Spectrum& s){
 
 bool MzMLWriter::writeSpectra(MSObject& o){
   for (int i = 0; i < o.size(); i++){
-    writeSpectra(o.at(i));
+    bool result = writeSpectra(o.at(i));
+    if(!result) {
+      return result;
+    }
   }
+  return true;
 }
 
 bool MzMLWriter::exportBinary(char* str, int len, int tabs){


### PR DESCRIPTION
Hi Mike,

Our Crux build is failing on Windows because the return type of `MzMLWriter::writeSpectra()` is [declared to be a boolean](https://github.com/wfondrie/mstoolkit/blob/a5692af215cd2e1739e9f69aec13815ccf56811d/include/mzMLWriter.h#L48), but currently doesn't return anything. 

This proposed change checks the result of each `writeSpectra()` call and returns `false` on the first one that fails or returns `true` if none fail.