### PR TITLE
generate index offset on the fly if scan index is missing for mzML/mzXML files

### DIFF
--- a/include/mzParser.h
+++ b/include/mzParser.h
@@ -588,6 +588,7 @@ private:
   void  pushSpectrum();  // Load current data into pvSpec, may have to guess charge
   f_off readIndexOffset();
   void  stopParser();
+  bool  generateIndexOffset();
 
   //  mzpSAXMzmlHandler Base64 conversion functions
   void decode(std::vector<double>& d);
@@ -688,6 +689,7 @@ private:
   void  pushSpectrum();  // Load current data into pvSpec, may have to guess charge
   f_off readIndexOffset();
   void  stopParser();
+  bool  generateIndexOffset();
 
   //  mzpSAXMzxmlHandler Base64 conversion functions
   void decode32();

--- a/src/mzIMLTools/CSubSample.cpp
+++ b/src/mzIMLTools/CSubSample.cpp
@@ -11,6 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "stdio.h"
+#include "stdlib.h"
 #include "CSubSample.h"
 
 using namespace std;

--- a/src/mzParser/saxmzmlhandler.cpp
+++ b/src/mzParser/saxmzmlhandler.cpp
@@ -897,7 +897,7 @@ f_off mzpSAXMzmlHandler::readIndexOffset() {
   }
 
   if(start==NULL || stop==NULL) {
-    cerr << "No index list offset found. File will not be read." << endl;
+//  cerr << "No index list offset found. File will not be read." << endl;
     return 0;
   }
 
@@ -917,13 +917,20 @@ bool mzpSAXMzmlHandler::load(const char* fileName){
   parseOffset(0);
   indexOffset = readIndexOffset();
   if(indexOffset==0){
-    m_bNoIndex=true;
-    return false;
+    m_bNoIndex=false;
+    if (!generateIndexOffset()) {
+       m_bNoIndex=true;
+       return false;
+    }
+
   } else {
     m_bNoIndex=false;
     if(!parseOffset(indexOffset)){ //Note: after reading index, should we check for order? assumes it is in file offset order.
-      cerr << "Cannot parse index. Make sure index offset is correct or rebuild index." << endl;
-      return false;
+       if (!generateIndexOffset()) {
+          m_bNoIndex=true;
+          cerr << "Cannot parse index. Make sure index offset is correct or rebuild index." << endl;
+          return false;
+       }
     }
     posIndex=-1;
     posChromatIndex=-1;
@@ -931,6 +938,68 @@ bool mzpSAXMzmlHandler::load(const char* fileName){
   return true;
 }
 
+//Parse file from top to bottom to generate index offset if not present.
+//If scan is present in native ID string, use it. Otherwise report spectrum index as scan number.
+bool mzpSAXMzmlHandler::generateIndexOffset() {
+  char chunk[CHUNK];
+  int readBytes;
+  long lOffset = 0;
+
+  if(!m_bGZCompression){
+    FILE* f=fopen(&m_strFileName[0],"r");
+    char *pStr;
+
+    if (f==NULL){
+      cout << "Error cannot open file " << m_strFileName[0] << endl;
+      exit(EXIT_FAILURE);
+    }
+
+    bool bReadingFirstSpectrum = true;
+    bool bThermoFile = false;
+
+    while (fgets(chunk, CHUNK, f)){
+
+      // Treat thermo files differently. Always report scan 'index' value which start at 0
+      // except for Thermo files where historically we're used to starting at scan 1.
+      if (strstr(chunk, "MS:1000768"))
+         bThermoFile = true;
+
+      if (strstr(chunk, "<spectrum ")){
+        long scanNum;
+        bool bSuccessfullyReadScan = false;
+        do{
+          // now need to look for "index="
+          if ((pStr = strstr(chunk, "index=\"")) != NULL){
+            sscanf(pStr+7, "%ld", &scanNum);
+            bSuccessfullyReadScan = true;
+          }
+
+          if ((pStr = strstr(chunk, "</spectrum>")) != NULL){
+            if (bSuccessfullyReadScan){  // not that we've reached the next spectrum, store index offset
+              if (bThermoFile)  // start scan count at 1 instead of 0
+                 scanNum += 1;
+              curIndex.scanNum = scanNum;
+              curIndex.idRef = "";
+              curIndex.offset = lOffset;
+              m_vIndex.push_back(curIndex);
+              break;
+            }
+            else{
+              printf(" error, found \"<spectrum\" line before parsing index attribute of previous scan:  %s\n", pStr);
+              return false;
+            }
+          }
+          bReadingFirstSpectrum = false;
+        } while (fgets(chunk, CHUNK, f));
+      }
+      lOffset = ftell(f);  // position of file pointer before fgets in loop
+    }
+  } else {
+    readBytes = gzObj.extract(fptr, gzObj.getfilesize()-200, (unsigned char*)chunk, CHUNK);
+  }
+
+  return true;
+}
 
 void mzpSAXMzmlHandler::stopParser(){
   m_bStopParse=true;

--- a/src/mzParser/saxmzxmlhandler.cpp
+++ b/src/mzParser/saxmzxmlhandler.cpp
@@ -597,7 +597,7 @@ f_off mzpSAXMzxmlHandler::readIndexOffset() {
   }
 
   if(start==NULL || stop==NULL) {
-    cerr << "No index list offset found. File will not be read." << endl;
+//  cerr << "No index list offset found. File will not be read." << endl;
     return 0;
   }
 
@@ -613,13 +613,19 @@ bool mzpSAXMzxmlHandler::load(const char* fileName){
   if(!open(fileName)) return false;
   indexOffset = readIndexOffset();
   if(indexOffset==0){
-    m_bNoIndex=true;
-    return false;
+    m_bNoIndex=false;
+    if (!generateIndexOffset()) {
+      m_bNoIndex=true;
+      return false;
+    }
   } else {
     m_bNoIndex=false;
     if(!parseOffset(indexOffset)){
-      cerr << "Cannot parse index. Make sure index offset is correct or rebuild index." << endl;
-      return false;
+      if (!generateIndexOffset()) {
+        m_bNoIndex=true;
+        cerr << "Cannot parse index. Make sure index offset is correct or rebuild index." << endl;
+        return false;
+      }
     }
     posIndex=-1;
   }
@@ -628,6 +634,48 @@ bool mzpSAXMzxmlHandler::load(const char* fileName){
   return true;
 }
 
+//Parse file from top to bottom to generate index offset if not present
+bool mzpSAXMzxmlHandler::generateIndexOffset() {
+  char chunk[CHUNK];
+  int readBytes;
+  long lOffset = 0;
+
+  if(!m_bGZCompression){
+    FILE* f=fopen(&m_strFileName[0],"r");
+    char *pStr;
+
+    if (f==NULL){
+      cout << "Error cannot open file " << m_strFileName[0] << endl;
+      exit(EXIT_FAILURE);
+    }
+
+    bool bReadingFirstSpectrum = true;
+
+    while (fgets(chunk, CHUNK, f)){
+      if (strstr(chunk, "<scan")){
+        long scanNum;
+        bool bSuccessfullyReadScan = false;
+        do{
+          // "<scan" and "num=" can be on different lines
+          if ((pStr = strstr(chunk, " num=\"")) != NULL){
+            sscanf(pStr+6, "%ld", &scanNum);
+            bSuccessfullyReadScan = true;
+            curIndex.scanNum = scanNum;
+            curIndex.idRef = "";
+            curIndex.offset = lOffset;
+            m_vIndex.push_back(curIndex);
+            break;
+          }
+        } while (fgets(chunk, CHUNK, f));
+      }
+      lOffset = ftell(f);  // position of file pointer before fgets in loop
+    }
+  } else {
+    readBytes = gzObj.extract(fptr, gzObj.getfilesize()-200, (unsigned char*)chunk, CHUNK);
+  }
+
+   return true;
+}
 
 void mzpSAXMzxmlHandler::stopParser(){
   m_bStopParse=true;


### PR DESCRIPTION
Mike, this is something I emailed you about back in late 2019.  It generates the index offset if not present in the file.  This allows these files to be accessed in lieu of just returning an error message stating the index is missing and the file cannot be read.  Helpful if it's incorporated into MSToolkit code otherwise I'll be patching Comet's version each time I update MSToolkit.