### PR TITLE
support positive/negative mode spectral state

### DIFF
--- a/include/Spectrum.h
+++ b/include/Spectrum.h
@@ -78,6 +78,7 @@ class Spectrum {
   double          getBPM();
   int             getCentroidStatus();
   int				      getCharge();
+  bool            getPositiveScan();
   double          getCompensationVoltage();
   double          getConversionA();
   double          getConversionB();
@@ -115,6 +116,7 @@ class Spectrum {
   void            setBPM(double);
   void            setCentroidStatus(int);
   void			    	setCharge(int);
+  void            setPositiveScan(bool);
   void            setCompensationVoltage(double);
   void            setConversionA(double);
   void            setConversionB(double);
@@ -171,6 +173,7 @@ class Spectrum {
   std::vector<double>   *vIonMobility;
   std::vector<ZState>   *vZ;         //presumed charge states and M+H; M can be monoisotopic or selected.
   int		           charge;
+  bool                 positiveScan;
   float		         rTime;
   int		           scanNumber;
   int              scanNumber2;

--- a/include/mzParser.h
+++ b/include/mzParser.h
@@ -1423,6 +1423,7 @@ struct ScanHeaderStruct {
   char   scanDescription[SCANTYPE_LENGTH]; //specific to Thermo instruments. Currently parsed from userParams in mzML...
         
   bool   centroid; //true if spectrum is centroided
+  bool   positiveScan; //true if positive mode or unknown, false if negative
   bool   ionMobility; //true if spectrum contains ion mobility data
   bool   possibleChargesArray[CHARGEARRAY_LENGTH]; /* NOTE: does NOT include "precursorCharge" information; only from "possibleCharges" */
    

--- a/src/MSToolkit/MSReader.cpp
+++ b/src/MSToolkit/MSReader.cpp
@@ -1403,6 +1403,7 @@ bool MSReader::readMZPFile(const char* c, Spectrum& s, int scNum){
 	s.setScanNumber(scanHeader.acquisitionNum);
 	s.setScanNumber(scanHeader.acquisitionNum,true);
 	s.setRTime((float)scanHeader.retentionTime/60.0f);
+  s.setPositiveScan(scanHeader.positiveScan);
   s.setCompensationVoltage(scanHeader.compensationVoltage);
   s.setInverseReducedIonMobility(scanHeader.inverseReducedIonMobility);
   s.setIonInjectionTime((float)scanHeader.ionInjectionTime);

--- a/src/MSToolkit/Spectrum.cpp
+++ b/src/MSToolkit/Spectrum.cpp
@@ -25,6 +25,7 @@ Spectrum::Spectrum(){
 
   rTime=0;
   charge=0;
+  positiveScan = true;
   scanNumber=0;
   scanNumber2=0;
   msLevel = 2;
@@ -82,6 +83,7 @@ Spectrum::Spectrum(const Spectrum& s){
 
   rTime = s.rTime;
   charge = s.charge;
+  positiveScan = s.positiveScan;
   scanNumber = s.scanNumber;
   scanNumber2 = s.scanNumber2;
   msLevel = s.msLevel;
@@ -163,6 +165,7 @@ Spectrum& Spectrum::operator=(const Spectrum& s){
     userParams = new vector<MSUserParam>(*s.userParams);
     rTime = s.rTime;
     charge = s.charge;
+    positiveScan = s.positiveScan;
     scanNumber = s.scanNumber;
     scanNumber2 = s.scanNumber2;
     msLevel = s.msLevel;
@@ -349,7 +352,8 @@ void Spectrum::clear(){
   scanNumber2 = 0;
 	rTime = 0;
 	charge = 0;
-	msLevel = 0;
+    positiveScan = true;
+    msLevel = 0;
   convA = 0;
   convB = 0;
   TIC = 0;
@@ -464,6 +468,9 @@ int Spectrum::getCharge(){
   return charge;
 }
 
+bool Spectrum::getPositiveScan(){
+  return positiveScan;
+}
 double Spectrum::getCompensationVoltage(){
   return compensationVoltage;
 }
@@ -615,6 +622,10 @@ void Spectrum::setCentroidStatus(int i){
 
 void Spectrum::setCharge(int i){
   charge=i;
+}
+
+void Spectrum::setPositiveScan(bool p){
+  positiveScan = p;
 }
 
 void Spectrum::setCompensationVoltage(double d){

--- a/src/mzParser/RAMPface.cpp
+++ b/src/mzParser/RAMPface.cpp
@@ -581,6 +581,7 @@ void mzParser::readHeader(RAMPFILE *pFI, ramp_fileoffset_t lScanIndex, struct Sc
   scanHeader->basePeakIntensity=pFI->bs->getBasePeakIntensity();
   scanHeader->basePeakMZ=pFI->bs->getBasePeakMZ();
   scanHeader->centroid=pFI->bs->getCentroid();
+  scanHeader->positiveScan=pFI->bs->getPositiveScan();
   scanHeader->collisionEnergy=pFI->bs->getCollisionEnergy();
   scanHeader->compensationVoltage=pFI->bs->getCompensationVoltage();																		
   scanHeader->highMZ=pFI->bs->getHighMZ();

--- a/src/mzParser/saxmzmlhandler.cpp
+++ b/src/mzParser/saxmzmlhandler.cpp
@@ -538,6 +538,9 @@ void mzpSAXMzmlHandler::processCVParam(const char* name, const char* accession, 
   } else if(!strcmp(name,"positive scan") || !strcmp(accession,"MS:1000130")) {
     spec->setPositiveScan(true);
 
+  } else if(!strcmp(name,"negative scan") || !strcmp(accession,"MS:1000129")) {
+    spec->setPositiveScan(false);
+
   } else if(!strcmp(name,"possible charge state") || !strcmp(accession,"MS:1000633")) {
     m_precursorIon.possibleCharges.push_back(atoi(value));
 


### PR DESCRIPTION
Hello,

This PR handles negative mode scans in mzParser and makes the polarity available in `Spectrum`.

Thanks,
Rick