### PR TITLE
small fix for data converted by TIMSCONVERT

### DIFF
--- a/src/mzParser/saxmzmlhandler.cpp
+++ b/src/mzParser/saxmzmlhandler.cpp
@@ -238,6 +238,7 @@ void mzpSAXMzmlHandler::startElement(const XML_Char *el, const XML_Char **attr){
     }
     m_peaksCount = atoi(getAttrValue("defaultArrayLength", attr));
     spec->setPeaksCount(m_peaksCount);
+    vdIM.clear(); // Added by Rick
 
   } else if (isElement("spectrumList",el)) {
     m_bInSpectrumList=true;


### PR DESCRIPTION
Hello,

When TIMS data is converted with [TIMSCONVERT](https://github.com/gtluu/timsconvert), it contains MS data with mobility arrays and MS2 spectra without. Since the `vdIM` buffer is not cleared across scans, a scan without the IMS array is incorrectly flagged as having one when the previous scan did have an array, see [here](https://github.com/mhoopmann/mstoolkit/blob/d6521094067c8185f957160bfeb7254889992349/src/mzParser/saxmzmlhandler.cpp#L841).

This tiny PR reset the buffer, but I honestly wasn't sure where the right place would be to do this so I just stuck it somewhere...

Thanks,
Rick