### PR TITLE
convert exit() calls to C++ exceptions

### DIFF
--- a/src/MSToolkit/MSReader.cpp
+++ b/src/MSToolkit/MSReader.cpp
@@ -15,6 +15,7 @@ limitations under the License.
 */
 #include "MSReader.h"
 #include <iostream>
+#include <stdexcept>
 using namespace std;
 using namespace MSToolkit;
 
@@ -457,9 +458,7 @@ bool MSReader::readMGFFile(const char* c, Spectrum& s){
 
   //Sanity check that we are at next spectrum
   if(strstr(strMGF,"BEGIN IONS")==NULL) {
-    cout << "Malformed MGF spectrum entry. Exiting." << endl;
-    cout << "line: " << strMGF << endl;
-    exit(-10);
+    throw std::runtime_error(std::string("Malformed MGF spectrum entry. Line: ") + std::string(strMGF));
   }
 
   //Read [next] spectrum header, modernization from JKE across entire while block
@@ -498,8 +497,7 @@ bool MSReader::readMGFFile(const char* c, Spectrum& s){
 
   //Process header information
   if(s.getMZ()==0) {
-    cout << "Error in MGF file: no PEPMASS found." << endl;
-    exit(-12);
+    throw std::runtime_error("Error in MGF file: no PEPMASS found.");
   }
   if(ch!=0){
     s.addZState(ch,s.getMZ()*ch-1.007276466*(ch-1));
@@ -530,14 +528,12 @@ bool MSReader::readMGFFile(const char* c, Spectrum& s){
 
     tok=strtok_r(strMGF," \t\n\r", &nextTok);
     if(tok==NULL){
-      cout << "Error in MGF file: bad m/z or intensity value." << endl;
-      exit(-13);
+      throw std::runtime_error("Error in MGF file: bad m/z or intensity value.");
     }
     mz=atof(tok);
     tok=strtok_r(NULL," \t\n\r", &nextTok);
     if(tok==NULL){
-      cout << "Error in MGF file: bad m/z or intensity value." << endl;
-      exit(-13);
+      throw std::runtime_error("Error in MGF file: bad m/z or intensity value.");
     }
     intensity=(float)atof(tok);
     if(!mgfOnePlus){
@@ -660,8 +656,7 @@ bool MSReader::readMGFFile2(const char* c, Spectrum& s){
     if (tokens[0].find("END IONS") != string::npos) {
       //convert any header information to MST spectrum information
       if (s.getMZ() == 0) {
-        cout << "Error in MGF file: no PEPMASS found." << endl;
-        exit(-12);
+        throw std::runtime_error("Error in MGF file: no PEPMASS found.");
       }
       if (ch != 0){
         s.addZState(ch, s.getMZ()*ch - 1.007276466*(ch - 1));
@@ -793,8 +788,7 @@ bool MSReader::readMSTFile(const char *c, bool text, Spectrum& s, int scNum){
     readSpecHeader(fileIn,ms);
 
     if(scNum<0) {
-      cerr << "ERROR: readMSTFile(): Cannot request previous scan. Function not supported. " << flush;
-      exit(1);
+      throw std::runtime_error("ERROR: readMSTFile(): Cannot request previous scan. Function not supported.");
     }
     if(scNum!=0){
 

--- a/src/mzParser/saxhandler.cpp
+++ b/src/mzParser/saxhandler.cpp
@@ -129,6 +129,8 @@ The End
 */
 
 #include "mzParser.h"
+#include <stdexcept>
+#include <string>
 using namespace std;
 using namespace mzParser;
 
@@ -305,33 +307,29 @@ bool mzpSAXHandler::parseOffset(f_off offset){
 			if(m_bStopParse) break;
 		}
 	}
+    if (!success && !m_bStopParse)
+    {
+        XML_Error error = XML_GetErrorCode(m_parser);
 
-	if (!success && !m_bStopParse)
-	{
-		XML_Error error = XML_GetErrorCode(m_parser);
+        std::string msg = std::string(m_strFileName) + "(" + std::to_string(XML_GetCurrentLineNumber(m_parser)) + ") : parseOffset() " + std::to_string((int)error) + ": ";
 
-		cerr << m_strFileName
-			<< "(" << XML_GetCurrentLineNumber(m_parser) << ")"
-			<< " : parseOffset() " << (int) error << ": ";
+        switch (error)
+        {
+            case XML_ERROR_SYNTAX:
+            case XML_ERROR_INVALID_TOKEN:
+            case XML_ERROR_UNCLOSED_TOKEN:
+                msg += "Syntax error parsing XML.";
+                break;
 
-		switch (error)
-		{
-			case XML_ERROR_SYNTAX:
-			case XML_ERROR_INVALID_TOKEN:
-			case XML_ERROR_UNCLOSED_TOKEN:
-				cerr << "Syntax error parsing XML." << endl;
-				break;
+            // TODO: Add more descriptive text for interesting errors.
 
-			// TODO: Add more descriptive text for interesting errors.
+            default:
+                msg += std::string("Spectrum XML Parsing error: ") + XML_ErrorString(error);
+                break;
+        }
 
-			default:
-				cerr << "Spectrum XML Parsing error:\n";
-				cerr << XML_ErrorString(error) << endl;
-				break;
-		} 
-		exit(-7);
-		return false;
-	}
+        throw std::runtime_error(msg);
+    }
 	return true;
 }
 

--- a/src/mzParser/saxmzmlhandler.cpp
+++ b/src/mzParser/saxmzmlhandler.cpp
@@ -34,6 +34,7 @@
  *******************************************************/
 
 #include "mzParser.h"
+#include <stdexcept>
 using namespace std;
 using namespace mzParser;
 
@@ -893,8 +894,7 @@ void mzpSAXMzmlHandler::decode(vector<double>& d){
       unzippedLen = m_peaksCount*sizeof(uint64_t);
     } else {
       if(!m_bNumpressLinear && !m_bNumpressSlof && !m_bNumpressPic){
-        cout << "Unknown data format to unzip. Stopping file read." << endl;
-        exit(EXIT_FAILURE);
+        throw std::runtime_error("Unknown data format to unzip. Stopping file read.");
       }
     //don't know the unzipped size of numpressed data, so assume it to be no larger than unpressed 64-bit data
     unzippedLen = m_peaksCount*sizeof(uint64_t);
@@ -922,8 +922,7 @@ void mzpSAXMzmlHandler::decode(vector<double>& d){
           else ms::numpress::MSNumpress::decodePic((unsigned char*)decoded,decodeLen,unpressed);
         }
     } catch (const char* ch){
-      cout << "Exception: " << ch << endl;
-      exit(EXIT_FAILURE);
+      throw std::runtime_error(std::string("Exception: ") + ch);
     }
 
     if(m_bZlib) delete [] unzipped;
@@ -1233,8 +1232,7 @@ bool mzpSAXMzmlHandler::generateIndexOffset() {
     char *pStr;
 
     if (f==NULL){
-      cout << "Error cannot open file " << m_strFileName[0] << endl;
-      exit(EXIT_FAILURE);
+      throw std::runtime_error(std::string("Error cannot open file ") + m_strFileName);
     }
 
     bool bReadingFirstSpectrum = true;

--- a/src/mzParser/saxmzxmlhandler.cpp
+++ b/src/mzParser/saxmzxmlhandler.cpp
@@ -19,6 +19,7 @@
  *******************************************************/
 
 #include "mzParser.h"
+#include <stdexcept>
 
 using namespace std;
 using namespace mzParser;
@@ -100,8 +101,7 @@ void mzpSAXMzxmlHandler::startElement(const XML_Char *el, const XML_Char **attr)
     if(!strcmp("zlib",&s[0])) m_bCompressedData=true;
     else if(!strcmp("none",&s[0])) m_bCompressedData=false;
     else if(s.length()>0) {
-      cout << "Halting! Unknown compression type: " <<  &s[0] << endl;
-      exit(-5);
+      throw std::runtime_error(std::string("Halting! Unknown compression type: ") + s);
     }
     s=getAttrValue("compressedLen", attr);
     if(s.length()>0) m_compressLen = (uLong)atoi(&s[0]);
@@ -473,9 +473,7 @@ void mzpSAXMzxmlHandler::decode32(){
     // an additional check of the data file integrity can be performed
     int length = b64_decode_mio( (char*) pDecoded , (char*) pData, stringSize );
     if(length != size) {
-      cout << " decoded size " << length << " and required size " << (unsigned long)size << " dont match:\n";
-      cout << " Cause: possible corrupted file.\n";
-      exit(EXIT_FAILURE);
+      throw std::runtime_error(std::string("Decoded size ") + std::to_string(length) + " and required size " + std::to_string((unsigned long)size) + " don't match: possible corrupted file.");
     }
   }
 
@@ -518,9 +516,7 @@ void mzpSAXMzxmlHandler::decode64(){
     // an additional check of the data file integrity can be performed
     int length = b64_decode_mio( (char*) pDecoded , (char*) pData, stringSize );
     if(length != size) {
-      cout << " decoded size " << length << " and required size " << (unsigned long)size << " dont match:\n";
-      cout << " Cause: possible corrupted file.\n";
-      exit(EXIT_FAILURE);
+      throw std::runtime_error(std::string("Decoded size ") + std::to_string(length) + " and required size " + std::to_string((unsigned long)size) + " don't match: possible corrupted file.");
     }
   }
 
@@ -655,8 +651,7 @@ bool mzpSAXMzxmlHandler::generateIndexOffset() {
     char *pStr;
 
     if (f==NULL){
-      cout << "Error cannot open file " << m_strFileName[0] << endl;
-      exit(EXIT_FAILURE);
+      throw std::runtime_error(std::string("Error cannot open file ") + m_strFileName);
     }
 
     bool bReadingFirstSpectrum = true;


### PR DESCRIPTION
Hello,

This PR replaces some code which calls `exit()` with C++ `throw` so errors can be handled more gracefully.